### PR TITLE
Make integration tests run on Travis !SAUCE_ENABLED

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,18 @@
 language: node_js
+sudo: required
+dist: trusty
 node_js:
   - stable
+before_install:
+  - export CHROME_BIN=/usr/bin/google-chrome
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - sudo apt-get update
+  - sudo apt-get install -y libappindicator1 fonts-liberation
+  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  - sudo dpkg -i google-chrome*.deb
+before_script:
+  - jdk_switcher use oraclejdk8
 addons:
   sauce_connect: true
 env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ To run the functional tests in dev mode (automatically reruns when a file change
 npm run karma:dev
 ```
 
-To run the integration tests locally with Chrome and FireFox (specified in [wdio.config.js](test/wdio.config.js)):
+To run the integration tests locally with Chrome (specified in [wdio.config.js](test/wdio.config.js)):
 
 ```bash
 npm run wdio

--- a/test/wdio.config.js
+++ b/test/wdio.config.js
@@ -50,8 +50,8 @@ const sauceConfig = sauceEnabled
 exports.config = Object.assign({
   specs: ['./test/integration/**/*.js'],
   capabilities: [
-    { browserName: 'chrome' },
-    { browserName: 'firefox' }
+    // { browserName: 'firefox' },
+    { browserName: 'chrome' }
   ],
   baseUrl: 'http://localhost:' + staticServerPort,
   screenshotPath: './screenshots/',


### PR DESCRIPTION
This should allow us to do integration testing on PRs from forks.

In addition to this, I've changed the `SAUCE_ENABLED` variable to be a private one on Travis to prevent it from being set to true on fork PRs.

See:

- https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
- dwyl/learn-nightwatch#8