### PR TITLE
Add a null option support for `enhanceSelectElement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 _(add items here for easier creation of next log entry)_
+- Add support for handling null/placeholder options when using `enhanceSelectElement`
 
 ## 1.0.3 - 2017-05-15
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,32 @@ This function takes the same options as `accessibleAutocomplete`, with the only 
 
 > **Note**: The `accessibleAutocomplete.enhanceSelectElement` function is fairly light and wraps the public API for `accessibleAutocomplete`. If your use case doesn't fit the above defaults, try [reading the source](src/wrapper.js) and seeing if you can write your own.
 
+### Null options
+
+If your `<select>` element has a "null" option - a default option with no value - then you can pass a `defaultValue` option to `enhanceSelectElement` which will replace the label of this option when it is selected.
+
+With the following HTML:
+
+```html
+<select id="location-picker">
+  <option value="">Select a country</option>
+  <option value="fr">France</option>
+  <option value="de">Germany</option>
+  <option value="gb">United Kingdom</option>
+</select>
+```
+
+Then passing a `defaultValue` option of `''` will then leave the autocomplete blank if the null option is selected.
+
+```js
+accessibleAutocomplete.enhanceSelectElement({
+  defaultValue: '',
+  selectElement: document.querySelector('#location-picker')
+})
+```
+
+Any null options will also be filtered out of the options used to populate the `source` of the autocomplete element. To preserve options with no value in the autcomplete then pass a `preserveNullOptions` flag of `true` to `enhanceSelectElement`.
+
 ## Analytics and tracking
 
 The following events get triggered on the input element during the life cycle of the autocomplete:

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -21,18 +21,19 @@ accessibleAutocomplete.enhanceSelectElement = (opts) => {
 
   // Set defaults.
   if (!opts.source) {
-    const availableOptions = Array.prototype.map.call(opts.selectElement.options, o => o.innerHTML)
+    let availableOptions = [].filter.call(opts.selectElement.options, o => (o.value || opts.preserveNullOptions))
+    availableOptions = availableOptions.map(o => o.innerHTML)
     opts.source = createSimpleEngine(availableOptions)
   }
   opts.onConfirm = opts.onConfirm || (query => {
-    const requestedOption = Array.prototype.filter.call(opts.selectElement.options, o => o.innerHTML === query)[0]
+    const requestedOption = [].filter.call(opts.selectElement.options, o => o.innerHTML === query)[0]
     if (requestedOption) { requestedOption.selected = true }
   })
-  if (!opts.defaultValue && opts.defaultValue !== '') {
+
+  if (opts.selectElement.value || opts.defaultValue === undefined) {
     opts.defaultValue = opts.selectElement.options[opts.selectElement.options.selectedIndex].innerHTML
-  } else {
-    opts.selectElement.value = opts.defaultValue
   }
+
   opts.name = opts.name || ''
   opts.id = opts.id || opts.selectElement.id || ''
   opts.autoselect = opts.autoselect || true


### PR DESCRIPTION
Allows the common pattern for `<select>` elements in forms to have a default option with no value and a placeholder text to be supported out of the box.

### Changes
* Uses `defaultValue` only when the `<select>` element has no selected value (i.e. when a null option is selected)
* Filters out any null-valued options from the option list used to populate the `source` array for autocomplete
* Adds a flag to optionally not apply the above filter

### Tests
* Refactors the `enhanceSelectElement` tests to reduce repetition of setup code
* Removes some of the test scope for `can enhance a select element` on the basis that it's too vague to be helpful. Assertions have been split out into more specific tests