### PR TITLE
Fix `version` script to compile assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "preversion": "npm test",
     "standard": "standard",
     "test": "run-p standard karma wdio",
-    "version": "npm build && git add -A dist",
+    "version": "npm run build && git add -A dist",
     "wdio": "wdio test/wdio.config.js && git checkout dist/"
   },
   "dependencies": {


### PR DESCRIPTION
`npm build` is not equivalent to `npm run build` - we need the latter here.