### PR TITLE
Fix onChange/onInput event handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ import preact from 'preact'
 import Autocomplete from 'accessible-autocomplete/preact'
 
 preact.render(
-  <Autocomplete source={suggest} />,
+  <Autocomplete id='autocomplete' source={suggest} />,
   document.querySelector('#container')
 )
 ```
@@ -91,7 +91,7 @@ import ReactDOM from 'react-dom'
 import Autocomplete from 'accessible-autocomplete/react'
 
 ReactDOM.render(
-  <Autocomplete source={suggest} />,
+  <Autocomplete id='autocomplete' source={suggest} />,
   document.querySelector('#container')
 )
 ```
@@ -108,7 +108,7 @@ Type: `HTMLElement`
 
 The container element in which the autocomplete will be rendered in.
 
-#### `id` (default: `'autocomplete'`)
+#### `id`
 
 Type: `string`
 

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -1,6 +1,9 @@
 import { createElement, Component } from 'preact' /** @jsx createElement */
 import Status from './status'
 
+const IS_PREACT = process.env.COMPONENT_LIBRARY === 'PREACT'
+const IS_REACT = process.env.COMPONENT_LIBRARY === 'REACT'
+
 const keyCodes = {
   13: 'enter',
   27: 'escape',
@@ -28,6 +31,12 @@ function isPrintableKeyCode (keyCode) {
     (keyCode > 185 && keyCode < 193) || // ;=,-./` (in order)
     (keyCode > 218 && keyCode < 223)    // [\]' (in order)
   )
+}
+
+// Preact does not implement onChange on inputs, but React does.
+function onChangeCrossLibrary (handler) {
+  if (IS_PREACT) { return { onInput: handler } }
+  if (IS_REACT) { return { onChange: handler } }
 }
 
 export default class Autocomplete extends Component {
@@ -385,7 +394,7 @@ export default class Autocomplete extends Component {
           className={`${inputClassName}${inputModFocused}`}
           id={id}
           onBlur={this.handleInputBlur}
-          onChange={this.handleInputChange}
+          {...onChangeCrossLibrary(this.handleInputChange)}
           onFocus={this.handleInputFocus}
           name={name}
           placeholder={placeholder}

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -36,7 +36,6 @@ export default class Autocomplete extends Component {
     cssNamespace: 'autocomplete',
     defaultValue: '',
     displayMenu: 'inline',
-    id: 'autocomplete',
     minLength: 0,
     name: 'input-autocomplete',
     placeholder: '',


### PR DESCRIPTION
I naively changed this from an `onInput` to an `onChange` when I saw that it "worked fine" in Preact. However, it wasn't working in reality; the `pollInputElement` handler was making it look like it.

We can't use `onInput` in both Preact and React because it fails in React on IE10.

Also removed the confusing / unused default for the `id` prop.