### PR TITLE
Update prepush script to only look at file names

### DIFF
--- a/scripts/check-staged.js
+++ b/scripts/check-staged.js
@@ -1,8 +1,9 @@
 const cp = require('child_process')
 const chalk = require('chalk')
 
-cp.exec('git diff dist/', (err, stdout) => {
+cp.exec('git diff --name-only dist/', (err, stdout) => {
   if (err) {
+    console.log(chalk.red('ERROR:'), err)
     return process.exit(1)
   }
   if (stdout.toString().length) {


### PR DESCRIPTION
The prepush script will fail when `git diff dist/` returns a really long output which causes Node to throw `stdout maxBuffer exceeded`.

`git diff --name-only` outputs only the changed filenames which is much shorter.

Also display the actual stack trace in the event of an unexpected error.