### PR TITLE
Redirect /dist/ assets to route

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -85,6 +85,11 @@ const config = {
   devtool: ENV === 'production' ? 'source-map' : 'cheap-module-eval-source-map',
 
   devServer: {
+    setup (app) {
+      app.get('/dist/:filename', (request, response) => {
+        response.redirect('/' + request.params.filename)
+      })
+    },
     port: process.env.PORT || 8080,
     host: 'localhost',
     publicPath: '/dist/',


### PR DESCRIPTION
This is so that we can have github pages and the dev server work alongside.
Since github pages relies on the structure of the repo, whereas webpack-dev-server does not.

Fixes #253