### PR TITLE
Pin Firefox version for SauceLabs tests

### DIFF
--- a/test/wdio.config.js
+++ b/test/wdio.config.js
@@ -21,7 +21,8 @@ const sauceConfig = sauceEnabled
       {
         browserName: 'firefox',
         build: buildNumber,
-        platform: 'Windows 10'
+        platform: 'Windows 10',
+        version: '55.0'
       },
       {
         browserName: 'internet explorer',


### PR DESCRIPTION
Part fix for failing Travis build reported in
https://github.com/alphagov/accessible-autocomplete/issues/253

We hadn't tied SauceLabs to a version of Firefox. We haven't done
active development on the repo for a bit so it looks like the latest FF is not
compatible.

Tested as part of this PR: https://github.com/alphagov/accessible-autocomplete/pull/254

I wonder if we should specify Chrome version as well? 