### PR TITLE
Update docs for React version

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ ReactDOM.render(
 
 [Try out the React example!](https://alphagov.github.io/accessible-autocomplete/examples/react/)
 
+#### React versions
+
+React v15.5.4 has been tested to work with the Accessible Autocomplete - although make sure to check
+out [documented issues](https://github.com/alphagov/accessible-autocomplete/issues).
+
+React v15.6.2 and 16.0 have been incompletely tested with the Accessible Autocomplete: while no undocumented issues were found, we recommend you carry out thorough testing if you wish to use these or later versions of React.
+
 ## API documentation
 
 ### Required options


### PR DESCRIPTION
This details that 15.5.4 was the last version of React tested to work with the Accessible Autocomplete (barring any documented issues) and versions 15.6.2 and 16.0 have received some basic testing.