### PR TITLE
Fix asset paths for subdirectories

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -86,8 +86,13 @@ const config = {
 
   devServer: {
     setup (app) {
-      app.get('/dist/:filename', (request, response) => {
-        response.redirect('/' + request.params.filename)
+      // Grab potential subdirectory with :dir*?
+      app.get('/dist/:dir*?/:filename', (request, response) => {
+        if (!request.params.dir || request.params.dir === undefined) {
+          response.redirect('/' + request.params.filename)
+        } else {
+          response.redirect('/' + request.params.dir + '/' + request.params.filename)
+        }
       })
     },
     port: process.env.PORT || 8080,


### PR DESCRIPTION
This redirects any requests for assets in dist/[subdirectory] correctly.

Fixes the issue of React and Preact examples not having their asset paths set correctly on local: http://localhost:8080/react/ and http://localhost:8080/preact/ would 404 for assets.

Related to: #254

Note: Duplicates https://github.com/alphagov/accessible-autocomplete/pull/264 that was closed by mistake. 