### PR TITLE
fix fill-rule attribute, JSX required camel case fillRule

### DIFF
--- a/src/dropdown-arrow-down.js
+++ b/src/dropdown-arrow-down.js
@@ -2,7 +2,7 @@ import { createElement } from 'preact' /** @jsx createElement */
 
 const DropdownArrowDown = ({ className }) => (
   <svg version='1.1' xmlns='http://www.w3.org/2000/svg' className={className} focusable='false'>
-    <g stroke='none' fill='none' fill-rule='evenodd'>
+    <g stroke='none' fill='none' fillRule='evenodd'>
       <polygon fill='#000000' points='0 0 22 0 11 17' />
     </g>
   </svg>


### PR DESCRIPTION
### Changes

This should fix a console warning I see when using the `Autocomplete` component in our React (vs 16) project. The attribute appears misnamed, JSX requires a camel case equivalent, see https://reactjs.org/docs/dom-elements.html#all-supported-svg-attributes

### Screenshot
Before this change I get a console warning:

![](https://cl.ly/3N2I2z1x1I2z/Image%202018-07-04%20at%209.41.29%20AM.png)