### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ If this is set to `true`, all values are shown when the user clicks the input. T
 to a default dropdown, so the autocomplete is rendered with a dropdown arrow to convey
 this behaviour.
 
-#### `showNoResultsFound` (default: `true`)
+#### `showNoOptionsFound` (default: `true`)
 
 Type: `Boolean`
 


### PR DESCRIPTION
Hi, I've struggled with turning off the "No Results Found" message inside my autocomplete input with "showNoResultsFound" prop, when I've found typo in your docs. In your code I've found that it's "showNoOptionsFound" not "showNoResultsFound".