### PR TITLE
Fix failing integration tests

### DIFF
--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -7,7 +7,7 @@ const isIE = browserName === 'internet explorer'
 // const isIE9 = isIE && version === '9'
 // const isIE10 = isIE && version === '10'
 // const isIE11 = isIE && version === '11.103'
-const liveRegionWaitTimeMillis = 2000
+const liveRegionWaitTimeMillis = 10000
 
 const basicExample = () => {
   describe('basic example', function () {
@@ -39,31 +39,35 @@ const basicExample = () => {
       expect(browser.isVisible(menu)).to.equal(true)
     })
 
-    it('should announce status changes using two alternately updated aria live regions', () => {
-      const flip = browser.$('div#ariaLiveA')
-      const flop = browser.$('div#ariaLiveB')
+    // These tests are flakey when run through Saucelabs so we only run them
+    // in Chrome
+    if (isChrome) {
+      it('should announce status changes using two alternately updated aria live regions', () => {
+        const flip = browser.$('div#ariaLiveA')
+        const flop = browser.$('div#ariaLiveB')
 
-      browser.click(input)
-      browser.setValue(input, 'a')
-      expect(flip.getText()).to.equal('')
-      expect(flop.getText()).to.equal('')
-      browser.waitUntil(() => { return flip.getText() !== '' },
-        liveRegionWaitTimeMillis,
-        'expected the first aria live region to be populated within ' + liveRegionWaitTimeMillis + ' milliseconds'
-      )
-      browser.addValue(input, 's')
-      browser.waitUntil(() => { return (flip.getText() === '' && flop.getText() !== '') },
-        liveRegionWaitTimeMillis,
-        'expected the first aria live region to be cleared, and the second to be populated within ' +
-        liveRegionWaitTimeMillis + ' milliseconds'
-      )
-      browser.addValue(input, 'h')
-      browser.waitUntil(() => { return (flip.getText() !== '' && flop.getText() === '') },
-        liveRegionWaitTimeMillis,
-        'expected the first aria live region to be populated, and the second to be cleared within ' +
-        liveRegionWaitTimeMillis + ' milliseconds'
-      )
-    })
+        browser.click(input)
+        browser.setValue(input, 'a')
+        expect(flip.getText()).to.equal('')
+        expect(flop.getText()).to.equal('')
+        browser.waitUntil(() => { return flip.getText() !== '' },
+          liveRegionWaitTimeMillis,
+          'expected the first aria live region to be populated within ' + liveRegionWaitTimeMillis + ' milliseconds'
+        )
+        browser.addValue(input, 's')
+        browser.waitUntil(() => { return (flip.getText() === '' && flop.getText() !== '') },
+          liveRegionWaitTimeMillis,
+          'expected the first aria live region to be cleared, and the second to be populated within ' +
+          liveRegionWaitTimeMillis + ' milliseconds'
+        )
+        browser.addValue(input, 'h')
+        browser.waitUntil(() => { return (flip.getText() !== '' && flop.getText() === '') },
+          liveRegionWaitTimeMillis,
+          'expected the first aria live region to be populated, and the second to be cleared within ' +
+          liveRegionWaitTimeMillis + ' milliseconds'
+        )
+      })
+    }
 
     describe('keyboard use', () => {
       it('should allow typing', () => {


### PR DESCRIPTION
### Problem
We are seeing the following intergration tests for the Accessible Autocomplete fail as they don't complete within the set time limit of 2000ms:
```
it('should announce status changes using two alternately updated aria live regions', () => {
      if (isChrome) {
        const flip = browser.$('div#ariaLiveA')
        const flop = browser.$('div#ariaLiveB')

        browser.click(input)
        browser.setValue(input, 'a')
        expect(flip.getText()).to.equal('')
        expect(flop.getText()).to.equal('')
        browser.waitUntil(() => { return flip.getText() !== '' },
          liveRegionWaitTimeMillis,
          'expected the first aria live region to be populated within ' + liveRegionWaitTimeMillis + ' milliseconds'
        )
        browser.addValue(input, 's')
        browser.waitUntil(() => { return (flip.getText() === '' && flop.getText() !== '') },
          liveRegionWaitTimeMillis,
          'expected the first aria live region to be cleared, and the second to be populated within ' +
          liveRegionWaitTimeMillis + ' milliseconds'
        )
        browser.addValue(input, 'h')
        browser.waitUntil(() => { return (flip.getText() !== '' && flop.getText() === '') },
          liveRegionWaitTimeMillis,
          'expected the first aria live region to be populated, and the second to be cleared within ' +
          liveRegionWaitTimeMillis + ' milliseconds'
        )
      }
    })
```
![Screen Shot 2019-09-17 at 09 27 13](https://user-images.githubusercontent.com/5007934/65234854-50303c00-dacd-11e9-8d0e-8fa17e036f1b.png)

This happens when they are run through Saucelabs/Selenium. When Saucelabs is not available, the tests are run through Puppeteer which seems to reliably pass.

## Solutions explored with @nickcolley 
### 1. Remove the timeout limit
Setting timeout on waitUntil is optional.

However removing it throws
```
Promise was rejected for the following reason: timeout
```
### 2. Increase the timeout limit
- Chrome on Saucelabs would intermittently fail within 2000ms; Firefox and IE would always fail
- On 3000ms Firefox and IE11 would still fail.
- On 4000ms IE11 was flaky.
- IE10 needed at least 6000ms to pass, whilst IE9 wouldn't pass even at 10000ms.
- Additionally, Firefox would fail intermittently regardless of the timeout limit set.

### 3. Limit the browsers the tests run in
As Chrome seemed most reliable to run the tests with, we used the isChrome check to limit the Saucelabs tests only to run in Chrome on Windows 10.

However even then we would occassionally see the tests in Chrome fail within the 2000ms limit.

![chrome-fail-2000](https://user-images.githubusercontent.com/5007934/65234963-8bcb0600-dacd-11e9-8e4a-24ee3272022b.png)

We increased the limit to 10000ms, at which point no issues were observed.

### 4. Move the tests to /tests/functional
Saucelabs runs tests in tests/integration. Puppeteer run tests in tests/functional.

Tests on the original PR would have been run through Puppeteer as Saucelabs wasn't available. They seem too flaky to run through Saucelabs because of timer issues so we investigated moving them to /tests/functional.

However we found that trying to create the interactive component for testing was really difficult.

edit for reference: @markhunter27 suggested 
> We could create a narrower / more focussed functional test that would only assert on the 'bump' state of the component, as that's what's driving which aria live region is targeted. The test could look much the same as the silencing test that's already there (and is also using a timeout). If we call the render() method a couple of times, we should see the bump boolean flip each time. It wouldn't be the full on integration test - like the silencing test it stops short of the markup that comes out of the render() method, but it does test the state generation and assumes we react to the new state correctly within render()

However whilst adding this functional test for the bump state as suggested by @markhunter27 is a good idea, we decided that since the functional tests only run in Chrome it'll be covered by the existing integration tests.

## 5. Change the tests config
Investigate adding a file that has the same capabilities as tests in /integration (Webdriver?) but is run through Puppeteer rather than Saucelabs. This could be helpful in the future for creating integration tests that don't require Saucelabs.

We weren't sure there was value in this work at this point so didn't much exploration of it.

## 6. Remove the tests
Saucelabs is flaky when running timer based tests. Remove these tests and leave a code comment to say if the aria-live region code is changed, it should be tested manually.

### Proposed solution
Solutions 2 and 3 to keep some test coverage, while also trying to ensure that our PRs don't start failing due to Saucelabs timer issues. With this in mind, keep an eye on the tests on CI going forward.