### PR TITLE
Dismiss open autocompletes between tests

### DIFF
--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -19,7 +19,11 @@ const basicExample = () => {
     const secondOption = `${menu} > li:nth-child(2)`
 
     beforeEach(() => {
-      browser.setValue(input, '') // Prevent autofilling, IE likes to do this.
+      // Dismiss any open autocompletes
+      browser.addValue(input, ['Escape'])
+
+      // Prevent autofilling, IE likes to do this.
+      browser.setValue(input, '')
     })
 
     it('should show the input', () => {


### PR DESCRIPTION
Clearing the value doesn’t seem to work reliably when the autocomplete is currently open, especially if it has been interacted with (e.g. in a test that sends the arrow down key to focus on a result)

By sending ‘escape’ we dismiss any open autocompletes, which then seems to make the input-clearing work reliably.