### PR TITLE
Remove retries for functional tests

### DIFF
--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,4 +1,4 @@
-/* global afterEach, before, beforeEach, browser, describe, it */
+/* global afterEach, beforeEach, browser, describe, it */
 const expect = require('chai').expect
 const { browserName, version } = browser.desiredCapabilities
 const isChrome = browserName === 'chrome'
@@ -15,14 +15,6 @@ const basicExample = () => {
     const menu = `${input} + ul`
     const firstOption = `${menu} > li:first-child`
     const secondOption = `${menu} > li:nth-child(2)`
-
-    beforeEach(() => {
-      // Dismiss any open autocompletes
-      browser.addValue(input, ['Escape'])
-
-      // Prevent autofilling, IE likes to do this.
-      browser.setValue(input, '')
-    })
 
     it('should show the input', () => {
       browser.waitForExist(input)
@@ -187,7 +179,7 @@ const takeScreenshotsIfFail = () => {
 }
 
 describe('Accessible Autocomplete', () => {
-  before(() => {
+  beforeEach(() => {
     browser.url('/')
   })
 
@@ -202,7 +194,7 @@ describe('Accessible Autocomplete', () => {
 })
 
 describe('Accessible Autocomplete Preact', () => {
-  before(() => {
+  beforeEach(() => {
     browser.url('/preact')
   })
 
@@ -216,7 +208,7 @@ describe('Accessible Autocomplete Preact', () => {
 })
 
 describe('Accessible Autocomplete React', () => {
-  before(() => {
+  beforeEach(() => {
     browser.url('/react')
   })
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -11,8 +11,6 @@ const liveRegionWaitTimeMillis = 10000
 
 const basicExample = () => {
   describe('basic example', function () {
-    this.retries(3)
-
     const input = 'input#autocomplete-default'
     const menu = `${input} + ul`
     const firstOption = `${menu} > li:first-child`
@@ -143,8 +141,6 @@ const basicExample = () => {
 
 const customTemplatesExample = () => {
   describe('custom templates example', function () {
-    this.retries(3)
-
     const input = 'input#autocomplete-customTemplates'
     const menu = `${input} + ul`
     const firstOption = `${menu} > li:first-child`

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -37,29 +37,51 @@ const basicExample = () => {
     // in Chrome
     if (isChrome) {
       it('should announce status changes using two alternately updated aria live regions', () => {
-        const flip = browser.$('#autocomplete-default__status--A')
-        const flop = browser.$('#autocomplete-default__status--B')
+        const regionA = browser.$('#autocomplete-default__status--A')
+        const regionB = browser.$('#autocomplete-default__status--B')
+
+        expect(regionA.getText()).to.equal('')
+        expect(regionB.getText()).to.equal('')
 
         browser.click(input)
         browser.setValue(input, 'a')
-        expect(flip.getText()).to.equal('')
-        expect(flop.getText()).to.equal('')
-        browser.waitUntil(() => { return flip.getText() !== '' },
+
+        // We can't tell which region will be used first, so we have to allow for
+        // either region changing
+        browser.waitUntil(() => { return regionA.getText() !== '' || regionB.getText() !== '' },
           liveRegionWaitTimeMillis,
           'expected the first aria live region to be populated within ' + liveRegionWaitTimeMillis + ' milliseconds'
         )
-        browser.addValue(input, 's')
-        browser.waitUntil(() => { return (flip.getText() === '' && flop.getText() !== '') },
-          liveRegionWaitTimeMillis,
-          'expected the first aria live region to be cleared, and the second to be populated within ' +
-          liveRegionWaitTimeMillis + ' milliseconds'
-        )
-        browser.addValue(input, 'h')
-        browser.waitUntil(() => { return (flip.getText() !== '' && flop.getText() === '') },
-          liveRegionWaitTimeMillis,
-          'expected the first aria live region to be populated, and the second to be cleared within ' +
-          liveRegionWaitTimeMillis + ' milliseconds'
-        )
+
+        if (regionA.getText()) {
+          browser.addValue(input, 's')
+          browser.waitUntil(() => { return (regionA.getText() === '' && regionB.getText() !== '') },
+            liveRegionWaitTimeMillis,
+            'expected the first aria live region to be cleared, and the second to be populated within ' +
+            liveRegionWaitTimeMillis + ' milliseconds'
+          )
+
+          browser.addValue(input, 'h')
+          browser.waitUntil(() => { return (regionA.getText() !== '' && regionB.getText() === '') },
+            liveRegionWaitTimeMillis,
+            'expected the first aria live region to be populated, and the second to be cleared within ' +
+            liveRegionWaitTimeMillis + ' milliseconds'
+          )
+        } else {
+          browser.addValue(input, 's')
+          browser.waitUntil(() => { return (regionA.getText() !== '' && regionB.getText() === '') },
+            liveRegionWaitTimeMillis,
+            'expected the first aria live region to be populated, and the second to be cleared within ' +
+            liveRegionWaitTimeMillis + ' milliseconds'
+          )
+
+          browser.addValue(input, 'h')
+          browser.waitUntil(() => { return (regionA.getText() === '' && regionB.getText() !== '') },
+            liveRegionWaitTimeMillis,
+            'expected the first aria live region to be cleared, and the second to be populated within ' +
+            liveRegionWaitTimeMillis + ' milliseconds'
+          )
+        }
       })
     }
 


### PR DESCRIPTION
The [wdio-sauce-service](https://github.com/webdriverio/webdriverio/tree/83dbe5d5c12fdb91b12db8c02cf2b8b50cfbd608/packages/wdio-sauce-service), which is responsible for reporting the build state back to Saucelabs, does not seem to take into account retries – we _believe_ that if a test fails, it will mark the build as failed in Saucelabs even if it is then retried and passes. This is confusing, as it does not match what we see in the Mocha reporter either locally or in the Travis build logs.

Using retries also masks situations where for example the autocomplete state is not reset correctly between tests, and thus the first attempt of a test always fails.

For these reasons, we're going to try removing retries and see what problems it causes (or, to look at another way, unmasks)