### PR TITLE
Release version 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## Unreleased
 
+## 2.0.2 - 2020-01-30
+
 ### Fixes
 
-- [Pull request #388: Set aria-selected as a string instead of a boolean to avoid being dropped.](https://github.com/alphagov/accessible-autocomplete/pull/388)
-- [Pull request #400: Remove pointer events check](https://github.com/alphagov/accessible-autocomplete/pull/400)
-- [Pull request #406: Make hint padding match input padding](https://github.com/alphagov/accessible-autocomplete/pull/406)
-- [Pull request #407: Use a div element to wrap enhanced component.](https://github.com/alphagov/accessible-autocomplete/pull/407)
-- [Pull request #410: Fix long clicks not selecting options](https://github.com/alphagov/accessible-autocomplete/pull/410)
+- [Pull request #388: Set aria-selected as a string instead of a boolean to avoid being dropped](https://github.com/alphagov/accessible-autocomplete/pull/388).
+- [Pull request #400: Remove pointer events check](https://github.com/alphagov/accessible-autocomplete/pull/400).
+- [Pull request #406: Make hint padding match input padding](https://github.com/alphagov/accessible-autocomplete/pull/406).
+- [Pull request #407: Use a div element to wrap enhanced component](https://github.com/alphagov/accessible-autocomplete/pull/407).
+- [Pull request #410: Fix long clicks not selecting options](https://github.com/alphagov/accessible-autocomplete/pull/410).
 
 ## 2.0.1 - 2019-10-07
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "accessible-autocomplete",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "accessible-autocomplete",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "dist/accessible-autocomplete.min.js",
   "style": "dist/accessible-autocomplete.min.css",
   "description": "An autocomplete component, built to be accessible.",


### PR DESCRIPTION
## Changelog


### Fixes

- [Pull request #388: Set aria-selected as a string instead of a boolean to avoid being dropped](https://github.com/alphagov/accessible-autocomplete/pull/388).
- [Pull request #400: Remove pointer events check](https://github.com/alphagov/accessible-autocomplete/pull/400).
- [Pull request #406: Make hint padding match input padding](https://github.com/alphagov/accessible-autocomplete/pull/406).
- [Pull request #407: Use a div element to wrap enhanced component](https://github.com/alphagov/accessible-autocomplete/pull/407).
- [Pull request #410: Fix long clicks not selecting options](https://github.com/alphagov/accessible-autocomplete/pull/410).