### PR TITLE
Pin Sauce Connect Proxy version to fix local tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 before_script:
   - jdk_switcher use oraclejdk8
 env:
-  - CXX=g++-4.8 SAUCE_CONNECT_VERSION=4.5.4
+  - CXX=g++-4.8
 addons:
   apt:
     sources:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "standard": "standard",
     "test": "run-p standard karma wdio",
     "version": "npm run build && git add -A dist",
-    "wdio": "cross-env NODE_ENV=test wdio test/wdio.config.js && git checkout dist/"
+    "wdio": "cross-env NODE_ENV=test SAUCE_CONNECT_VERSION=4.5.4 wdio test/wdio.config.js && git checkout dist"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
https://github.com/alphagov/accessible-autocomplete/pull/443 pinned the Sauce Connect Proxy for Travis. https://github.com/alphagov/accessible-autocomplete/pull/450 will update WebDriverIO to v6 so we no longer need to pin the version - the PR is currently blocked as we’re speaking to SauceLabs to see if we can enable the tests for IE9 with WebDriverIO v6.

This PR adds a temporary fix to unblock https://github.com/alphagov/accessible-autocomplete/pull/447. We can remove this in https://github.com/alphagov/accessible-autocomplete/pull/450.