### PR TITLE
Improve docs for publishing a new version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,8 +138,14 @@ npm version <major|minor|patch> -m "## 1.2.3 - 2017-01-13
 
 - Change included in this release
 - Another change included in this release"
+```
+
+Then run:
+```bash
 git push --tags --set-upstream origin refs/heads/v1.2.3:refs/heads/v1.2.3
 ```
+
+Create a pull request for the release.
 
 To actually publish, you will need access to an `npm` account that owns `accessible-autocomplete`. Merge the version PR and then run:
 
@@ -148,3 +154,16 @@ git checkout master
 git pull --rebase
 npm publish
 ```
+
+[Create a new release](https://github.com/alphagov/accessible-autocomplete/releases/new) on GitHub.
+  1. Select the latest tag version.
+  2. Set "v[VERSION-NUMBER]" as the title.
+  3. Add the release notes from the changelog.
+  4. Add a summary of highlights.
+  5. Publish the release.
+
+You don't need to manually attach source code files to the release on GitHub.
+
+Post a short summary of the release in the cross-government and GDS #govuk-design-system Slack channels. For example:
+
+🚀 We’ve just released Accessible Autocomplete v2.0.1. You can now use the acccessible autocomplete multiple times on one page. Thanks to @<SLACK-NAME> and @<SLACK-NAME> for helping with this release. [https://github.com/alphagov/accessible-autocomplete/releases/tag/v2.0.1](https://github.com/alphagov/accessible-autocomplete/releases/tag/v2.0.1)


### PR DESCRIPTION
- Split command for pushing the tag onto a separate line to visually distinguish it from the multi-line command above it.
- Add steps for publishing a release on Github and announcing it.