### PR TITLE
Add className attribute to status component

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -431,6 +431,7 @@ export default class Autocomplete extends Component {
     const wrapperClassName = `${cssNamespace}__wrapper`
 
     const inputClassName = `${cssNamespace}__input`
+    const statusClassName = `${cssNamespace}__status`
     const componentIsFocused = focused !== null
     const inputModifierFocused = componentIsFocused ? ` ${inputClassName}--focused` : ''
     const inputModifierType = this.props.showAllValues ? ` ${inputClassName}--show-all-values` : ` ${inputClassName}--default`
@@ -484,6 +485,7 @@ export default class Autocomplete extends Component {
           tNoResults={tStatusNoResults}
           tSelectedOption={tStatusSelectedOption}
           tResults={tStatusResults}
+          className={statusClassName}
         />
 
         {hintValue && (

--- a/src/status.js
+++ b/src/status.js
@@ -62,7 +62,8 @@ export default class Status extends Component {
       tQueryTooShort,
       tNoResults,
       tSelectedOption,
-      tResults
+      tResults,
+      className
     } = this.props
     const { bump, debounced, silenced } = this.state
 
@@ -86,6 +87,7 @@ export default class Status extends Component {
 
     return (
       <div
+        className={className}
         style={{
           border: '0',
           clip: 'rect(0 0 0 0)',


### PR DESCRIPTION
The status component is currently hidden from view using inline CSS, however in an implementation that applies aggressive CSP controls these styles cannot be applied, and since the status element has minimal other identifying attributes, it is difficult to apply corresponding styles in .css files.

Apply a class attribute to the status component - defaulting to `autocomplete__status` so that it can be reliably targeted by CSS selectors.