### PR TITLE
Update Travis config to paralellize builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,12 @@ sudo: required
 dist: trusty
 before_install:
   - export DISPLAY=:99.0
+  - export CXX=g++-4.8
   - sh -e /etc/init.d/xvfb start
   - sudo apt-get update
   - sudo apt-get install -y libappindicator1 fonts-liberation
 before_script:
   - jdk_switcher use oraclejdk8
-env:
-  - CXX=g++-4.8
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,16 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+jobs:
+  include:
+    - name: "Lint"
+      env: TEST_SUITE=standard
+    - name: "Functional tests (Puppeteer)"
+      env: TEST_SUITE=karma
+    - name: "Integration tests (SauceLabs)"
+      env: TEST_SUITE=wdio
+      if: type = pull_request OR branch = master
+script:
+  - npm run $TEST_SUITE
 after_success:
   - cat ./coverage/lcov/lcov.info | ./node_modules/coveralls/bin/coveralls.js


### PR DESCRIPTION
I think it would be good to have a Travis build for each test suite, rather than a single Travis build that tests everything. I think this would help in two ways:

1. It should result in more reliability; I've noticed that tests often fail because Travis runs too many jobs at once and SauceLabs only allows 5 connections at a time on the open source plan [[1]]. My hypothesis is that this is because Travis is running the tests twice (once as branch and once as a pull request), and so we're exceeding the SauceLabs quota. Having a job for each test suite means we can skip the SauceLabs tests if it isn't a pull request test.

3. It will result in quicker feedback if tests fail. It might also result in a small overall *increase* in time taken to run all tests, but I think this is less of a problem if you can restart the test that failed only.

[1]: https://saucelabs.com/solutions/open-source