### PR TITLE
if no option is focused, remove the aria-activedescendant attribute from the input

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -492,7 +492,7 @@ export default class Autocomplete extends Component {
 
         <input
           aria-expanded={menuOpen ? 'true' : 'false'}
-          aria-activedescendant={optionFocused ? `${id}__option--${focused}` : false}
+          aria-activedescendant={optionFocused ? `${id}__option--${focused}` : undefined}
           aria-owns={`${id}__listbox`}
           aria-autocomplete={(this.hasAutoselect()) ? 'both' : 'list'}
           {...ariaDescribedProp}


### PR DESCRIPTION
With react/preact, setting the `aria-activedescendant` attribute to `undefined` is how we can remove the attribute.

This issue was first report in a comment on https://github.com/alphagov/accessible-autocomplete/issues/361#issuecomment-532789525