### PR TITLE
Add correct default behaviour for autoselect

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,11 @@ function suggest (query, populateResults) {
 
 ### Other options
 
-#### `autoselect` (default: `false`)
+#### `autoselect` (default: `true`)
 
 Type: `Boolean`
 
-Set to true to highlight the first option when the user types in something and receives results. Pressing enter will select it.
+Leave set to `true` to highlight the first option when the user types in something and receives results. Pressing enter will select it.
 
 #### `confirmOnBlur` (default: `true`)
 


### PR DESCRIPTION
Fixes [#466](https://github.com/alphagov/accessible-autocomplete/issues/466).

This PR corrects the README's previous wording, which said `autoselect` defaults to `false`.