### PR TITLE
Add timeout for testing with SauceLabs

### DIFF
--- a/.github/workflows/saucelabs.yaml
+++ b/.github/workflows/saucelabs.yaml
@@ -16,6 +16,7 @@ jobs:
   test-saucelabs:
     name: Build & test (with Sauce Labs)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     # Only run tests using Sauce Labs if PR was not raised from a fork.
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}


### PR DESCRIPTION
For reasons we don't yet understand, this step is sometimes getting stuck [^1] and never finishing, until either: 

- someone notices and cancels the workflow run
- it hits the default GitHub Actions timeout of 360 minutes (6 hours)

Either way, this is way longer than this job needs – when the tests run successfully they complete in around 2.5 minutes.

Reduce the timeout to 15 minutes for the job to avoid wasting resources, until we can solve the underlying issue with the workflow.

[^1]: Examples of builds getting 'stuck':
    - https://github.com/alphagov/accessible-autocomplete/actions/runs/1922517196/attempts/1
    - https://github.com/alphagov/accessible-autocomplete/actions/runs/1897972486/attempts/1
    - https://github.com/alphagov/accessible-autocomplete/actions/runs/1894436033