### PR TITLE
Update GitHub Actions workflows with `.nvmrc`

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: "Run integration tests"
+      - name: Run browser tests (without Sauce Labs)
         run: npm run wdio:test
         env:
-          SAUCE_ENABLED: "false"  # ensure we don't use Sauce Labs
+          SAUCE_ENABLED: false

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,7 +1,13 @@
 name: Integration tests
 
-on: [push, pull_request]
+on:
+  pull_request:
 
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
 
 jobs:
   test-saucelabs:

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
 
       - name: Read node version from .nvmrc
         id: nvm

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -9,8 +9,12 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: integration-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
-  test-saucelabs:
+  integration:
     name: Build & test
     runs-on: ubuntu-latest
 

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -18,15 +18,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
 
-      - name: Read node version from .nvmrc
-        id: nvm
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-
-      - name: "Setup Node v${{ steps.nvm.outputs.NVMRC }}"
-        uses: actions/setup-node@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.0
         with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
-          cache: 'npm'
+          cache: npm
+          check-latest: true
+          node-version-file: .nvmrc
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/saucelabs.yaml
+++ b/.github/workflows/saucelabs.yaml
@@ -25,15 +25,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
 
-      - name: Read node version from .nvmrc
-        id: nvm
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-
-      - name: "Setup Node v${{ steps.nvm.outputs.NVMRC }}"
-        uses: actions/setup-node@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.0
         with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
-          cache: 'npm'
+          cache: npm
+          check-latest: true
+          node-version-file: .nvmrc
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/saucelabs.yaml
+++ b/.github/workflows/saucelabs.yaml
@@ -1,8 +1,5 @@
 name: Cross-browser tests
 
-# Our Sauce Labs account only allows 5 tests to run at a time.
-concurrency: saucelabs
-
 on:
   pull_request:
 
@@ -12,8 +9,11 @@ on:
 
   workflow_dispatch:
 
+# Our Sauce Labs account only allows 5 tests to run at a time.
+concurrency: saucelabs
+
 jobs:
-  test-saucelabs:
+  saucelabs:
     name: Build & test (with Sauce Labs)
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/saucelabs.yaml
+++ b/.github/workflows/saucelabs.yaml
@@ -38,10 +38,10 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: "Run cross-browser tests (using Sauce Labs)"
+      - name: Run browser tests (with Sauce Labs)
         run: npm run wdio:test
         env:
-          SAUCE_ENABLED: "true"
-          SAUCE_BUILD_NUMBER: "${{ github.run_id }}"
-          SAUCE_USERNAME: "${{ secrets.SAUCE_USERNAME }}"
-          SAUCE_ACCESS_KEY: "${{ secrets.SAUCE_ACCESS_KEY }}"
+          SAUCE_ENABLED: true
+          SAUCE_BUILD_NUMBER: ${{ github.run_id }}
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/saucelabs.yaml
+++ b/.github/workflows/saucelabs.yaml
@@ -3,14 +3,14 @@ name: Cross-browser tests
 # Our Sauce Labs account only allows 5 tests to run at a time.
 concurrency: saucelabs
 
-# Run for pull requests, or after changes to main branch, but not for any old
-# branch, to limit number of workflows contending for Sauce Labs access.
 on:
+  pull_request:
+
   push:
     branches:
       - main
-  pull_request:
 
+  workflow_dispatch:
 
 jobs:
   test-saucelabs:

--- a/.github/workflows/saucelabs.yaml
+++ b/.github/workflows/saucelabs.yaml
@@ -22,7 +22,8 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
 
       - name: Read node version from .nvmrc
         id: nvm

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,13 @@
 name: Test
 
-on: [pull_request, push]
+on:
+  pull_request:
+
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,12 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: tests-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  test:
     name: Build & basic tests
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
 
       - name: Read node version from .nvmrc
         id: nvm

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,15 +18,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
 
-      - name: Read node version from .nvmrc
-        id: nvm
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-
-      - name: "Setup Node v${{ steps.nvm.outputs.NVMRC }}"
-        uses: actions/setup-node@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.0
         with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
-          cache: 'npm'
+          cache: npm
+          check-latest: true
+          node-version-file: .nvmrc
 
       - name: Install dependencies
         run: npm ci

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-14.18.2
+lts/fermium

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,22 +15,12 @@ $ npm -v
 v6.14.18
 ```
 
-If you want to run the selenium tests, you will also need a local copy of the Java Development Kit:
-
-```bash
-$ java -version
-java version "1.8.0_131"
-Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
-Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
-```
-
-To install Node (with npm) and Java locally on macOS, we recommend [brew](https://brew.sh) with 
+To install Node (with npm) locally on macOS, we recommend [brew](https://brew.sh) with
 [nvm](https://github.com/nvm-sh/nvm):
 
 ```bash
 brew install nvm
 nvm install
-brew cask install java
 ```
 
 ## Project structure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,13 @@ If you want to help and want to get more familiar with the codebase, try startin
 
 ## Requirements
 
-You will need a recent version of Node and npm installed:
+You will need a recent version of Node and npm installed. Check the `.nvmrc` for a recommended version:
 
 ```bash
 $ node -v
-v7.10.0
+v14.21.3
 $ npm -v
-v5.0.0
+v6.14.18
 ```
 
 If you want to run the selenium tests, you will also need a local copy of the Java Development Kit:
@@ -24,10 +24,12 @@ Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
 Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
 ```
 
-To install Node (with npm) and Java locally on macOS, you can use [brew](https://brew.sh/):
+To install Node (with npm) and Java locally on macOS, we recommend [brew](https://brew.sh) with 
+[nvm](https://github.com/nvm-sh/nvm):
 
 ```bash
-brew install node
+brew install nvm
+nvm install
 brew cask install java
 ```
 


### PR DESCRIPTION
Addresses deprecation warnings in GitHub Actions ahead of package updates

>[**Build & test**](https://github.com/alphagov/accessible-autocomplete/actions/runs/6904010579/job/18787315977)
>The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-node@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

I've included an **.nvmrc** update ~to test things out but this might land in https://github.com/alphagov/accessible-autocomplete/pull/609 first~ cherry picked from https://github.com/alphagov/accessible-autocomplete/pull/609/commits/c7995df49c7644240378f2908675b7c6c80f1fb3