### PR TITLE
Update all dependencies using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+updates:
+  # Update npm packages
+  - package-ecosystem: npm
+    directory: /
+    open-pull-requests-limit: 10
+
+    reviewers:
+      - alphagov/design-system-developers
+
+    # Schedule run every Monday, local time
+    schedule:
+      interval: weekly
+      time: '10:30'
+      timezone: 'Europe/London'
+
+    versioning-strategy: increase
+
+    allow:
+      # Include direct package.json updates
+      - dependency-type: direct
+
+      # Include indirect browser data updates
+      # https://caniuse.com
+      - dependency-name: caniuse-lite

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,40 @@ updates:
     directory: /
     open-pull-requests-limit: 10
 
+    # Group packages into shared PR
+    groups:
+      build:
+        patterns:
+          - '@babel/*'
+          - 'babel-*'
+          - 'core-js'
+          - 'csso-cli'
+          - 'preact'
+          - 'source-map-loader'
+          - 'terser-*'
+          - 'webpack'
+          - 'webpack-*'
+
+      test:
+        patterns:
+          - '@wdio/*'
+          - 'chai'
+          - 'devtools'
+          - 'karma'
+          - 'karma-*'
+          - 'mocha'
+          - 'puppeteer'
+          - 'standard'
+          - 'webdriverio'
+
+      tools:
+        patterns:
+          - 'chalk'
+          - 'cross-env'
+          - 'dotenv'
+          - 'husky'
+          - 'npm-run-all'
+
     reviewers:
       - alphagov/design-system-developers
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,15 @@ updates:
       # Include indirect browser data updates
       # https://caniuse.com
       - dependency-name: caniuse-lite
+
+  # Update GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    reviewers:
+      - alphagov/design-system-developers
+
+    # Schedule run every Monday, local time
+    schedule:
+      interval: weekly
+      time: '10:30'
+      timezone: 'Europe/London'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,9 @@ updates:
     reviewers:
       - alphagov/design-system-developers
 
-    # Schedule run every Monday, local time
+    # Schedule run on 1st of every month, local time
     schedule:
-      interval: weekly
+      interval: monthly
       time: '10:30'
       timezone: 'Europe/London'
 
@@ -31,8 +31,8 @@ updates:
     reviewers:
       - alphagov/design-system-developers
 
-    # Schedule run every Monday, local time
+    # Schedule run on 1st of every month, local time
     schedule:
-      interval: weekly
+      interval: monthly
       time: '10:30'
       timezone: 'Europe/London'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,10 @@ jobs:
       - name: Functional tests (Chromium)
         run: npm run karma
 
-      # Run linter last so other tests run even if there is a code formatting error
+      # Run linter after tests to prevent failure due to code formatting error
       - name: Lint
         run: npm run standard
+
+      # Run check for `npm run build` unstaged changes
+      - name: Check for unstaged changes
+        run: node scripts/check-staged.mjs


### PR DESCRIPTION
This PR enables Dependabot updates for npm and GitHub Actions including:

1. Checks run at `monthly` intervals
2. Checks for unstaged changes after build
3. Grouped PRs for "build", "test" and "tooling" dependencies

Previously only security-related updates were included

~Probably wait for https://github.com/alphagov/accessible-autocomplete/pull/612 to merge first~