### PR TITLE
Add Composer Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "accessible-autocomplete",
+    "name": "alphagov/accessible-autocomplete",
     "description": "An autocomplete component, built to be accessible.",
     "version": "2.0.4",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bbertucc/accessible-autocomplete",
+    "name": "alphagov/accessible-autocomplete",
     "description": "An autocomplete component, built to be accessible.",
     "version": "2.0.4",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,25 +1,25 @@
 {
-  "name": "accessible-autocomplete",
-  "description": "An autocomplete component, built to be accessible.",
-  "version": "2.0.4,
-  "keywords": [
-    "a11y",
-    "accessibility",
-    "autocomplete",
-    "component",
-    "plugin",
-    "typeahead",
-    "widget"
-  ],
-  "homepage": "https://alphagov.github.io/accessible-autocomplete/examples/",
-  "authors": [
-    {
-      "name": "Government Digital Service",
-      "homepage": "https://www.gov.uk/government/organisations/government-digital-service"
-    }
-  ],
-  "support": {
-    "issues": "https://github.com/alphagov/accessible-autocomplete/issuess"
-  },
-  "license": "MIT",
+    "name": "accessible-autocomplete",
+    "description": "An autocomplete component, built to be accessible.",
+    "version": "2.0.4",
+    "keywords": [
+        "a11y",
+        "accessibility",
+        "autocomplete",
+        "component",
+        "plugin",
+        "typeahead",
+        "widget"
+    ],
+    "homepage": "https://alphagov.github.io/accessible-autocomplete/examples/",
+    "authors": [
+        {
+            "name": "Government Digital Service",
+            "homepage": "https://www.gov.uk/government/organisations/government-digital-service"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/alphagov/accessible-autocomplete/issuess"
+    },
+    "license": "MIT",
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+  "name": "accessible-autocomplete",
+  "description": "An autocomplete component, built to be accessible.",
+  "version": "2.0.4,
+  "keywords": [
+    "a11y",
+    "accessibility",
+    "autocomplete",
+    "component",
+    "plugin",
+    "typeahead",
+    "widget"
+  ],
+  "homepage": "https://alphagov.github.io/accessible-autocomplete/examples/",
+  "authors": [
+    {
+      "name": "Government Digital Service",
+      "homepage": "https://www.gov.uk/government/organisations/government-digital-service"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/alphagov/accessible-autocomplete/issuess"
+  },
+  "license": "MIT",
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "alphagov/accessible-autocomplete",
+    "name": "bbertucc/accessible-autocomplete",
     "description": "An autocomplete component, built to be accessible.",
     "version": "2.0.4",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,5 @@
     "support": {
         "issues": "https://github.com/alphagov/accessible-autocomplete/issuess"
     },
-    "license": "MIT",
+    "license": "MIT"
 }


### PR DESCRIPTION
[Equalify](http://equalify.app) would love to include accessible-autocomplete via Composer. This file should set up the package. You'll just need to merge it and submit the repo to [the packagist](https://packagist.org/packages/submit).