### PR TITLE
Fix various Karma + webpack warnings and minor issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:css": "csso src/autocomplete.css -o dist/accessible-autocomplete.min.css",
     "build:js": "cross-env NODE_ENV=production webpack --progress",
     "build": "run-s \"build:js\" \"build:css\"",
-    "dev": "cross-env NODE_ENV=development webpack-dev-server",
+    "dev": "cross-env NODE_ENV=development webpack serve",
     "karma:dev": "cross-env NODE_ENV=test karma start test/karma.config.js",
     "karma": "npm run karma:dev -- --single-run",
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -31,6 +31,12 @@ module.exports = function (config) {
       // than Preact [1] or React [2] configs
       ...webpackConfig.default[0],
 
+      // Use Karma managed test entry points
+      entry: undefined,
+
+      // Use Karma default `os.tmpdir()` output
+      output: undefined,
+
       // Suppress webpack performance warnings due to
       // Karma chunked output and inline source maps
       performance: { hints: false },

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -3,7 +3,7 @@ require('@babel/register')({
 })
 
 const puppeteer = require('puppeteer')
-const webpack = require('../webpack.config.mjs').default[0]
+const webpackConfig = require('../webpack.config.mjs')
 
 // Use Chrome headless
 process.env.CHROME_BIN = puppeteer.executablePath()
@@ -26,10 +26,15 @@ module.exports = function (config) {
       '**/*.js': ['sourcemap']
     },
 
-    webpack,
-    webpackMiddleware: {
-      logLevel: 'error',
-      stats: 'errors-only'
+    webpack: {
+      // Use standalone webpack config [0] rather
+      // than Preact [1] or React [2] configs
+      ...webpackConfig.default[0],
+
+      // Suppress webpack performance warnings due to
+      // Karma chunked output and inline source maps
+      performance: { hints: false },
+      stats: { preset: 'errors-only' }
     }
   })
 }

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -4,14 +4,17 @@ import { cwd } from 'process'
 import TerserPlugin from 'terser-webpack-plugin'
 import webpack from 'webpack'
 
-const ENV = process.env.NODE_ENV || 'development'
-const PORT = process.env.PORT || 8080
+const {
+  NODE_ENV = 'development',
+  PORT = 8080
+} = process.env
 
-const plugins = [
-  new webpack.DefinePlugin({
-    'process.env.NODE_ENV': JSON.stringify(ENV)
-  })
-]
+/**
+ * Base webpack build mode
+ */
+const mode = NODE_ENV === 'development'
+  ? 'development'
+  : 'production'
 
 /**
  * Base webpack config
@@ -19,18 +22,15 @@ const plugins = [
  * @satisfies {WebpackConfiguration}
  */
 const config = {
-  bail: ENV === 'production',
+  bail: mode === 'production',
   context: join(cwd(), 'src'),
 
-  devtool: ENV === 'development'
+  devtool: mode === 'development'
     ? 'inline-source-map'
     : 'source-map',
 
   externalsType: 'umd',
-
-  mode: ENV === 'development'
-    ? 'development'
-    : 'production',
+  mode,
 
   module: {
     rules: [
@@ -60,8 +60,8 @@ const config = {
   },
 
   optimization: {
-    emitOnErrors: ENV === 'production',
-    minimize: ENV === 'production',
+    emitOnErrors: mode === 'production',
+    minimize: mode === 'production',
     minimizer: [new TerserPlugin({
       extractComments: true,
       terserOptions: {
@@ -133,10 +133,12 @@ const bundleStandalone = {
     }
   },
 
-  plugins: plugins
-    .concat([new webpack.DefinePlugin({
-      'process.env.COMPONENT_LIBRARY': '"PREACT"'
-    })])
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.COMPONENT_LIBRARY': '"PREACT"',
+      'process.env.NODE_ENV': `"${mode}"`
+    })
+  ]
 }
 
 /**
@@ -171,10 +173,12 @@ const bundlePreact = {
     globalObject: 'this'
   },
 
-  plugins: plugins
-    .concat([new webpack.DefinePlugin({
-      'process.env.COMPONENT_LIBRARY': '"PREACT"'
-    })])
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.COMPONENT_LIBRARY': '"PREACT"',
+      'process.env.NODE_ENV': `"${mode}"`
+    })
+  ]
 }
 
 /**
@@ -214,10 +218,12 @@ const bundleReact = {
     globalObject: 'this'
   },
 
-  plugins: plugins
-    .concat([new webpack.DefinePlugin({
-      'process.env.COMPONENT_LIBRARY': '"REACT"'
-    })])
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.COMPONENT_LIBRARY': '"REACT"',
+      'process.env.NODE_ENV': `"${mode}"`
+    })
+  ]
 }
 
 /**

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -8,7 +8,6 @@ const ENV = process.env.NODE_ENV || 'development'
 const PORT = process.env.PORT || 8080
 
 const plugins = [
-  new webpack.NoEmitOnErrorsPlugin(),
   new webpack.DefinePlugin({
     'process.env.NODE_ENV': JSON.stringify(ENV)
   })
@@ -20,6 +19,7 @@ const plugins = [
  * @satisfies {WebpackConfiguration}
  */
 const config = {
+  bail: ENV === 'production',
   context: join(cwd(), 'src'),
 
   devtool: ENV === 'development'
@@ -60,6 +60,7 @@ const config = {
   },
 
   optimization: {
+    emitOnErrors: ENV === 'production',
     minimize: ENV === 'production',
     minimizer: [new TerserPlugin({
       extractComments: true,

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -12,7 +12,7 @@ const {
 /**
  * Base webpack build mode
  */
-const mode = NODE_ENV === 'development'
+const mode = ['development', 'test'].includes(NODE_ENV)
   ? 'development'
   : 'production'
 


### PR DESCRIPTION
This PR includes a few follow-up fixes to Karma + webpack

### Fix Karma webpack output to prevent overwriting `dist/`

Previously `npm run karma` used webpack to overwrite `dist/` but using [`karma-webpack` defaults](https://github.com/codymikol/karma-webpack#default-webpack-configuration) instead. This has now been fixed so that Karma output is written to `os.tmpdir()` as the author intended

### Fix Karma webpack `karma-sourcemap-loader` warnings

Karma webpack `devtool` option now [outputs inline source maps](https://www.npmjs.com/package/karma-webpack#source-maps) to fix warnings about missing source maps

### Ensure webpack uses new `serve` CLI command

We can now use the webpack CLI rather than the `webpack-dev-server` package binary:

```console
npx webpack
npx webpack serve
```

### Ensure webpack always exits on build errors

The [webpack `NoEmitOnErrorsPlugin` plugin](https://webpack.js.org/plugins/NoEmitOnErrorsPlugin/) is now enabled by default but we turn it off in development mode to help diagnose problems in the browser rather than exit

# Warnings since webpack v5 update

Additionally, new warnings have been fixed following the webpack v5 update:

* https://github.com/alphagov/accessible-autocomplete/pull/614

### Fix Karma webpack performance warnings

The Karma webpack `stats: 'errors-only'` option has been updated for webpack v5 to ignore performance warning recommendations since these are only useful for production builds

### Fix Karma webpack `DefinePlugin` warning for `NODE_ENV`

The Karma webpack build runs with `NODE_ENV=test` but this logs a warning in webpack v5 because “test” does not match webpack `config.mode` allowed values `"none" | "development" | "production"`