### PR TITLE
[DO NOT MERGE] Testing against Preact 10

### DIFF
--- a/examples/preact/index.html
+++ b/examples/preact/index.html
@@ -60,7 +60,7 @@
     </main>
 
     <!-- We include the development version of Preact for debugging purposes. -->
-    <script type="text/javascript" src="https://unpkg.com/preact@8.1.0/dist/preact.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/preact@10.19.6/dist/preact.min.umd.js"></script>
     <script type="text/javascript" src="../../dist/lib/accessible-autocomplete.preact.min.js"></script>
     <script type="text/javascript">
       function suggest (query, syncResults) {


### PR DESCRIPTION
Updates the Preact example to load Preact 10 instead of 8 from unpkg (but keep our component built with Preact 8). This is a situation that may happen for people with a Preact project either started since version 10 got out or brought up to date, where a newer version of Preact may need to cohabitate with the version 8 that the component is built with.

Looking at the CI results, Chrome and Firefox work OK, but Internet Explorer has a failing test. The failing behaviour couldn't be reproduced on BrowserStack, so I think things are working alright for IE11.