### PR TITLE
Remove preact from dependabot build group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
           - 'mini-css-extract-plugin'
           - 'postcss'
           - 'postcss-*'
-          - 'preact'
           - 'source-map-loader'
           - 'terser-*'
           - 'webpack'


### PR DESCRIPTION
@romaricpascal sums it up well in [his comment](https://github.com/alphagov/accessible-autocomplete/pull/719#issuecomment-2277510897) on https://github.com/alphagov/accessible-autocomplete/pull/719