### PR TITLE
Add automatic redirects to examples for netlify previews

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/"
+  to = "/examples"
+  status = 301
+  


### PR DESCRIPTION
What it says on the tin. Adds a netlify.toml that only contains the redirect from "/" to "/examples". Used only for netlify previews right now so that folks not in the know aren't wondering why the root of the preview doesn't show anything.