### PR TITLE
Remove deprecated `reviewers` option from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,49 +10,46 @@ updates:
     groups:
       build:
         patterns:
-          - '@babel/*'
-          - 'autoprefixer'
-          - 'babel-*'
-          - 'core-js'
-          - 'cssnano'
-          - 'cssnano-*'
-          - 'css-loader'
-          - 'mini-css-extract-plugin'
-          - 'postcss'
-          - 'postcss-*'
-          - 'source-map-loader'
-          - 'terser-*'
-          - 'webpack'
-          - 'webpack-*'
+          - "@babel/*"
+          - "autoprefixer"
+          - "babel-*"
+          - "core-js"
+          - "cssnano"
+          - "cssnano-*"
+          - "css-loader"
+          - "mini-css-extract-plugin"
+          - "postcss"
+          - "postcss-*"
+          - "source-map-loader"
+          - "terser-*"
+          - "webpack"
+          - "webpack-*"
 
       test:
         patterns:
-          - '@wdio/*'
-          - 'chai'
-          - 'devtools'
-          - 'karma'
-          - 'karma-*'
-          - 'mocha'
-          - 'puppeteer'
-          - 'standard'
-          - 'webdriverio'
+          - "@wdio/*"
+          - "chai"
+          - "devtools"
+          - "karma"
+          - "karma-*"
+          - "mocha"
+          - "puppeteer"
+          - "standard"
+          - "webdriverio"
 
       tools:
         patterns:
-          - 'chalk'
-          - 'cross-env'
-          - 'dotenv'
-          - 'husky'
-          - 'npm-run-all'
-
-    reviewers:
-      - alphagov/design-system-developers
+          - "chalk"
+          - "cross-env"
+          - "dotenv"
+          - "husky"
+          - "npm-run-all"
 
     # Schedule run on 1st of every month, local time
     schedule:
       interval: monthly
-      time: '10:30'
-      timezone: 'Europe/London'
+      time: "10:30"
+      timezone: "Europe/London"
 
     versioning-strategy: increase
 
@@ -67,11 +64,9 @@ updates:
   # Update GitHub Actions
   - package-ecosystem: github-actions
     directory: /
-    reviewers:
-      - alphagov/design-system-developers
 
     # Schedule run on 1st of every month, local time
     schedule:
       interval: monthly
-      time: '10:30'
-      timezone: 'Europe/London'
+      time: "10:30"
+      timezone: "Europe/London"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,8 @@
 # Ensure any changes to GitHub Actions workflows are reviewed by developers
 .github/workflows/  @alphagov/design-system-developers
+
+# Track changes to package.json or package-lock.json
+/package*.json  @alphagov/design-system-developers
+
+# Protect the CODEOWNERS file itself against malicious changes
+CODEOWNERS  @alphagov/design-system-developers


### PR DESCRIPTION
Dependabot's `reviewers` option is being removed on 27th May, with its functionality being merged with the `CODEOWNERS` file, [as described on the GitHub blog](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).

## Changes
- Updates the `CODEOWNERS` file to include the **root** `package.json` and `package-lock.json` files explicitly, to match npm dependencies being protected by the `reviewers` option in Dependabot's config.
- Updates the `CODEOWNERS` file to include the `CODEOWNERS` file itself, requiring approval from codeowners to change it in future. [This is a recommended security practice.](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection)
- Removes the `reviewers` option from Dependabot config.
